### PR TITLE
Feature: Pass the configuration file as command line argument

### DIFF
--- a/src/main/java/ee/evrcargo/imap/Runner.java
+++ b/src/main/java/ee/evrcargo/imap/Runner.java
@@ -26,17 +26,34 @@ public class Runner {
             System.out.println("-c  check mailbox structure and calculate size");
             System.out.println("-r  restore mailbox");
             System.out.println();
+            System.out.println("--config <filename> Path to mbox.properties file");
+            System.out.println();
             System.out.println("Example: run.sh -c");
             System.exit(0);
-        } else if (args[0].compareTo("-b") == 0) {
-            task = new BackupMailbox();
-        } else if (args[0].compareTo("-c") == 0) {
-            task = new CheckMailbox();
-        } else if (args[0].compareTo("-r") == 0) {
-            task = new RestoreMailbox();
-        } else {
-            System.out.println("Unknown option");
-            System.exit(-1);
+        }
+        String config = null;
+        for (int i = 0; i < args.length; i++) {
+            switch (args[i]) {
+                case "-b":
+                    task = new BackupMailbox(config);
+                    break;
+                case "-c":
+                    task = new CheckMailbox(config);
+                    break;
+                case "-r":
+                    task = new RestoreMailbox(config);
+                    break;
+                case "--config":
+                    if (i == args.length-1) {
+                        System.out.println("Missing config file");
+                        System.exit(-1);
+                    }
+                    config = args[++i];
+                    break;
+                default:
+                    System.out.println("Unknown option");
+                    System.exit(-1);
+            }
         }
         task.execute();
         System.out.println("Execution time: " + (System.currentTimeMillis() - startTime) / 1000.0 + " sec.");

--- a/src/main/java/ee/evrcargo/imap/task/BackupMailbox.java
+++ b/src/main/java/ee/evrcargo/imap/task/BackupMailbox.java
@@ -21,13 +21,18 @@ import java.util.stream.Collectors;
 
 public class BackupMailbox implements Task {
     private static NumberFormat nf = NumberFormat.getNumberInstance();
-    Properties conf = Configuration.getInstance().getProps();
-    private final int maxRetries = Integer.parseInt(conf.getProperty("mailbox.retry.count"));
+    private final Properties conf;
+    private final int maxRetries;
+
+    public BackupMailbox(String config) {
+        conf = Configuration.getInstance().getProps(config);
+        maxRetries = Integer.parseInt(conf.getProperty("mailbox.retry.count"));
+    }
 
     @Override
     public void execute() {
         System.out.println("Executing backup for mailbox " + conf.getProperty("mailbox.user") + " to backup/" + conf.getProperty("mailbox.domain") + "/" + conf.getProperty("mailbox.user"));
-        ImapTree tree = new ImapTree();
+        ImapTree tree = new ImapTree(conf);
         List<FolderPath> paths = tree.build();
 
         // Crawl the folders

--- a/src/main/java/ee/evrcargo/imap/task/CheckMailbox.java
+++ b/src/main/java/ee/evrcargo/imap/task/CheckMailbox.java
@@ -11,13 +11,18 @@ import java.util.*;
 
 public class CheckMailbox implements Task {
     private static NumberFormat nf = NumberFormat.getNumberInstance();
-    private Properties conf = Configuration.getInstance().getProps();
-    private final int maxRetries = Integer.parseInt(conf.getProperty("mailbox.retry.count"));
+    private final Properties conf;
+    private final int maxRetries;
+
+    public CheckMailbox(String config) {
+        conf = Configuration.getInstance().getProps(config);
+        maxRetries = Integer.parseInt(conf.getProperty("mailbox.retry.count"));
+    }
 
     @Override
     public void execute() {
         System.out.println("Checking mailbox " + conf.getProperty("mailbox.user") + " at " + conf.getProperty("mailbox.domain"));
-        ImapTree tree = new ImapTree();
+        ImapTree tree = new ImapTree(conf);
         List<FolderPath> paths = tree.build();
 
         // Crawl the folders

--- a/src/main/java/ee/evrcargo/imap/task/RestoreMailbox.java
+++ b/src/main/java/ee/evrcargo/imap/task/RestoreMailbox.java
@@ -21,11 +21,16 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class RestoreMailbox implements Task {
-    private Properties conf = Configuration.getInstance().getProps();
-    private final int maxRetries = Integer.parseInt(conf.getProperty("mailbox.retry.count"));
+    private final Properties conf;
+    private final int maxRetries;
     private Session session = null;
     private Store store = null;
     private char separator;
+
+    public RestoreMailbox(String config) {
+        conf = Configuration.getInstance().getProps(config);
+        maxRetries = Integer.parseInt(conf.getProperty("mailbox.retry.count"));
+    }
 
     @Override
     public void execute() {
@@ -42,7 +47,7 @@ public class RestoreMailbox implements Task {
         }
 
         // Generate disk folder tree
-        FolderTree tree = new FolderTree();
+        FolderTree tree = new FolderTree(conf);
         List<FolderPath> paths = tree.build();
 
         // Crawl the folders

--- a/src/main/java/ee/evrcargo/imap/tree/FolderTree.java
+++ b/src/main/java/ee/evrcargo/imap/tree/FolderTree.java
@@ -1,7 +1,5 @@
 package ee.evrcargo.imap.tree;
 
-import ee.evrcargo.imap.Configuration;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -15,7 +13,12 @@ import java.util.stream.Collectors;
 
 public class FolderTree implements Tree {
     private List<FolderPath> mailboxMap = new ArrayList<>();
-    private Properties conf = Configuration.getInstance().getProps();
+    private final Properties conf;
+
+    public FolderTree(Properties conf) {
+        this.conf = conf;
+    }
+
 
     @Override
     public List<FolderPath> build() {

--- a/src/main/java/ee/evrcargo/imap/tree/ImapTree.java
+++ b/src/main/java/ee/evrcargo/imap/tree/ImapTree.java
@@ -1,7 +1,5 @@
 package ee.evrcargo.imap.tree;
 
-import ee.evrcargo.imap.Configuration;
-
 import javax.mail.Folder;
 import javax.mail.MessagingException;
 import javax.mail.Session;
@@ -12,9 +10,13 @@ import java.util.*;
 import static javax.mail.Folder.HOLDS_FOLDERS;
 
 public class ImapTree implements Tree {
-    private Properties conf = Configuration.getInstance().getProps();
+    private final Properties conf;
     private Store store;
     private List<FolderPath> mailboxMap = new ArrayList<>();
+
+    public ImapTree(Properties conf) {
+        this.conf = conf;
+    }
 
     @Override
     public List<FolderPath> build() {


### PR DESCRIPTION
I added a new command line option `--config <x/y/z/mbox.properties>` that allows users to specify the properties file they want to use. This is handy for users that want to backup multiple mailboxes from different hosts. 

If the new option is omitted, the old default paths are searched for configuration. 